### PR TITLE
Return ExtendedErrorInfo in addition to ErrDesc for Response->getError()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+##  [0.2.2] - 2017-01-30
+#### Added
+- Response ```getExtendedError```
+#### Changed
+- YourMembershipClient ```makeCall``` function now throws exception when the Response ```hasError```
+- Response ```getError``` reports the extended error if it available
+
+####
 ##  [0.2.1] - 2017-01-12
 #### Changed
 - Use Container to instantiate GuzzleClient in ServiceProvider

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "name": "Peter Arapov",
         "email": "petr@phone2action.com"
     }],
-    "version": "0.2.1",
+    "version": "0.2.2",
     "autoload": {
         "psr-4": {
             "P2A\\YourMembership\\": "src/"

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -45,7 +45,7 @@ class Response
 	}
 
 	/**
-	 * Fetches the Error Message From Response
+	 * Fetches the Error Message (including Extended Error Info) From Response
 	 * @method getError
 	 * @author PA
 	 * @date   2017-01-10
@@ -53,7 +53,13 @@ class Response
 	 */
 	public function getError() : string
 	{
-		return (string) $this->response->ErrDesc;
+	    $extendedErrorInfo = isset($this->response->ExtendedErrorInfo) ? (string) $this->response->ExtendedErrorInfo : '';
+	    $error = isset($this->response->ErrDesc) ? (string) $this->response->ErrDesc : '';
+	    if ($extendedErrorInfo) {
+	        $error .= " ($extendedErrorInfo)";
+        }
+
+		return $error;
 	}
 
 	/**

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -54,7 +54,10 @@ class Response
 	public function getError() : string
 	{
 	    $error = (string) $this->response->ErrDesc;
-	    if ($extendedError = $this->getExtendedError()) {
+
+		$extendedError = $this->getExtendedError();
+
+	    if ($extendedError) {
 	        $error .= " ($extendedError)";
         }
 

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -53,14 +53,24 @@ class Response
 	 */
 	public function getError() : string
 	{
-	    $extendedErrorInfo = isset($this->response->ExtendedErrorInfo) ? (string) $this->response->ExtendedErrorInfo : '';
-	    $error = isset($this->response->ErrDesc) ? (string) $this->response->ErrDesc : '';
-	    if ($extendedErrorInfo) {
-	        $error .= " ($extendedErrorInfo)";
+	    $error = (string) $this->response->ErrDesc;
+	    if ($extendedError = $this->getExtendedError()) {
+	        $error .= " ($extendedError)";
         }
 
 		return $error;
 	}
+
+    /**
+     * Fetches the Extended Error from the Response
+     * @return string
+     * @author TLS
+     * @date   1-30-2017
+     */
+	public function getExtendedError() : string
+    {
+        return isset($this->response->ExtendedErrorInfo) ? (string) $this->response->ExtendedErrorInfo : '';
+    }
 
 	/**
 	 * Converts the response to an Array

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -59,7 +59,7 @@ class Response
 	/**
 	 * Converts the response to an Array
 	 * @method toArray
-	 * @throws YourMembershipRequestException
+	 * @throws YourMembershipResponseException
 	 * @author PA
 	 * @date   2017-01-10
 	 * @return array      Response
@@ -72,7 +72,7 @@ class Response
 	/**
 	 * Converts the response to an Object
 	 * @method toObject
-	 * @throws YourMembershipRequestException
+	 * @throws YourMembershipResponseException
 	 * @author PA
 	 * @date   2017-01-11
 	 * @return stdClass  Response
@@ -87,7 +87,7 @@ class Response
 	 * Lossy conversion, attributes are lost from XML
 	 *
 	 * @method unwrapXMLObject
-	 * @throws YourMembershipRequestException
+	 * @throws YourMembershipResponseException
 	 * @author PA
 	 * @date   2017-01-11
 	 * @param  bool            $asArray unwrap the object into an array instead of object

--- a/tests/unit/Core/ResponseTest.php
+++ b/tests/unit/Core/ResponseTest.php
@@ -135,7 +135,7 @@ EOD;
         $response = $this->makeResponse('Member.Profile.Get', $this->errorResponseWithExtendedErrorXML);
 
         //Verify
-        $this->assertEquals('Method requires authentication. ([GroupCode] is invalid; it must be unique)', $response->getError());
+        $this->assertEquals('[GroupCode] is invalid; it must be unique', $response->getExtendedError());
     }
 
 

--- a/tests/unit/Core/ResponseTest.php
+++ b/tests/unit/Core/ResponseTest.php
@@ -30,6 +30,24 @@ class ResponseTest extends \Codeception\Test\Unit
 </YourMembership_Response>
 EOD;
 
+    private $errorResponseWithExtendedErrorXML = <<<'EOD'
+<?xml version="1.0" encoding="utf-8" ?>
+<YourMembership_Response>
+<ErrCode>403</ErrCode>
+<ExtendedErrorInfo>[GroupCode] is invalid; it must be unique</ExtendedErrorInfo>
+<ErrDesc>Method requires authentication.</ErrDesc>
+<XmlRequest>
+<YourMembership>
+<Version>2.25</Version>
+<ApiKey>3D638C5F-CCE2-4638-A2C1-355FA7BBC917</ApiKey>
+<CallID>001</CallID>
+<SessionID>A07C3BCC-0B39-4977-9E64-C00E918D572E</SessionID>
+<Call Method="Member.Profile.Get"></Call>
+</YourMembership>
+</XmlRequest>
+</YourMembership_Response>
+EOD;
+
 private $goodResponseXML = <<<'EOD'
 <?xml version="1.0" encoding="utf-8" ?>
 
@@ -103,7 +121,24 @@ EOD;
 
         //Verify
         $this->assertEquals('Method requires authentication.', $response->getError());
+
+        //Setup
+        $response = $this->makeResponse('Member.Profile.Get', $this->errorResponseWithExtendedErrorXML);
+
+        //Verify
+        $this->assertEquals('Method requires authentication. ([GroupCode] is invalid; it must be unique)', $response->getError());
     }
+
+    public function testGetExtendedError()
+    {
+        //Setup
+        $response = $this->makeResponse('Member.Profile.Get', $this->errorResponseWithExtendedErrorXML);
+
+        //Verify
+        $this->assertEquals('Method requires authentication. ([GroupCode] is invalid; it must be unique)', $response->getError());
+    }
+
+
     /**
      * @expectedException \P2A\YourMembership\Exceptions\YourMembershipResponseException
      */


### PR DESCRIPTION
If ExtendedErrorInfo is set, return that in the same string as ErrDesc inside `Response->getError()`

Resolves #10 